### PR TITLE
Check for `Kernel.then/2` as macro or function before redefining

### DIFF
--- a/lib/listiller.ex
+++ b/lib/listiller.ex
@@ -411,7 +411,7 @@ defmodule PhoenixLiveViewExt.Listiller do
 
 
   # Define the then/2 function unless already defined in Kernel
-  unless function_exported?( Kernel, :then, 2) do
+  unless macro_exported?( Kernel, :then, 2) || function_exported?( Kernel, :then, 2) do
     defp then( value, fun) do
       fun.( value)
     end


### PR DESCRIPTION
`Kernel.then/2` became a macro in https://github.com/elixir-lang/elixir/commit/9c5a21d8d571e557b1c308c37770b2bba713a580

This fixes a compilation bug in Elixir 1.12